### PR TITLE
[jenkins] Don't try to sign snapshot builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
                 branch 'master'
             }
             steps {
-                sh './mvnw clean deploy -Papache-release'
+                sh './mvnw clean deploy -Papache-release -Dgpg.skip=true'
             }
         }
     }


### PR DESCRIPTION
Because (1) we don't need to sign them and (2) Jenkins can't sign them, because it doesn't have any GPG keys.