### PR TITLE
Removes task dependencies in deploy when publishing snapshots

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
                 branch 'master'
             }
             steps {
-                sh './mvnw deploy -Papache-release -Dgpg.skip=true -DskipTests --batch-mode -pl -:brave-itests -nsu'
+                sh './mvnw deploy:deploy -Papache-release -Dgpg.skip=true -DskipTests --batch-mode -pl -:brave-itests -nsu'
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
                 branch 'master'
             }
             steps {
-                sh './mvnw deploy:deploy -Papache-release -Dgpg.skip=true -DskipTests --batch-mode -pl -:brave-itests -nsu'
+                sh './mvnw deploy:deploy -Papache-release -Dgpg.skip=true --batch-mode -pl -:brave-itests -nsu'
             }
         }
     }


### PR DESCRIPTION
Good idea from @shakuzen, we shouldn't need to run depedencies of deploy
as they are done prior.