### PR TITLE
Revert "Removes task dependencies in deploy when publishing snapshots"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
                 branch 'master'
             }
             steps {
-                sh './mvnw deploy:deploy -Papache-release -Dgpg.skip=true --batch-mode -pl -:brave-itests -nsu'
+                sh './mvnw deploy -Papache-release -Dgpg.skip=true -DskipTests --batch-mode -pl -:brave-itests -nsu'
             }
         }
     }


### PR DESCRIPTION
This reverts commit 0542a961802d7a1818fbf374b4a5fe2d423f7028 from #23

This broke the build, and while there's a hack to re-fix it, I don't think we want to think too much. Right now, most of our many repos have the luxury of near identical config. It would be a better optimization IMHO towards copy/paste vs having each project consider if it can or cannot get by with the jar:jar hack, or if it needs other configuration in order to make sure all intended artifacts end up getting out. 

https://stackoverflow.com/questions/6308162/maven-the-packaging-for-this-project-did-not-assign-a-file-to-the-build-artifac