### PR TITLE
Makes assembly create "incubating" filename and corrects baseDirectory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -516,38 +516,23 @@
       </build>
     </profile>
     <profile>
-      <id>release</id>
+      <id>apache-release</id>
       <build>
         <plugins>
-          <!-- Creates source jar -->
           <plugin>
-            <artifactId>maven-source-plugin</artifactId>
-            <version>3.0.1</version>
+            <artifactId>maven-assembly-plugin</artifactId>
             <executions>
               <execution>
-                <id>attach-sources</id>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-
-          <plugin>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.0.1</version>
-            <configuration>
-              <failOnError>false</failOnError>
-              <!-- hush pedantic warnings: we don't put param and return on everything! -->
-              <doclint>none</doclint>
-            </configuration>
-            <executions>
-              <execution>
-                <id>attach-javadocs</id>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-                <phase>package</phase>
+                <id>source-release-assembly</id>
+                <configuration>
+                  <!-- make the source release zip includes the word incubating -->
+                  <finalName>apache-zipkin-brave-karaf-incubating-${project.version}</finalName>
+                  <descriptors>
+                    <descriptor>src/main/assemblies/source-release.xml</descriptor>
+                  </descriptors>
+                  <!-- don't inherit the source-release as we are overriding it -->
+                  <descriptorRefs combine.self="override"/>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/src/main/assemblies/source-release.xml
+++ b/src/main/assemblies/source-release.xml
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly>
+  <id>source-release</id>
+  <!-- the only thing being done differently here is the base directory -->
+  <baseDirectory>brave-karaf-${version}</baseDirectory>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <componentDescriptors>
+    <componentDescriptor>assemblies/source-shared.xml</componentDescriptor>
+  </componentDescriptors>
+</assembly>


### PR DESCRIPTION
This removes some manual work I did to rename the zip created by the
package phase. It also corrects the base directly inside.

Thanks @abesto for noticing the latter!