### PR TITLE
Moves integration test to integration test phase

### DIFF
--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -169,6 +169,17 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/itests/src/test/java/io/zipkin/brave/itests/ITBrave.java
+++ b/itests/src/test/java/io/zipkin/brave/itests/ITBrave.java
@@ -47,7 +47,7 @@ import zipkin2.reporter.Sender;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
-public class BraveTest {
+public class ITBrave {
   private static final String FILTER_KAFKA = "(component.name=io.zipkin.sender.kafka)";
   private static final String FILTER_OKHTTP = "(component.name=io.zipkin.sender.okhttp)";
   private static final String FILTER_URLCONNECTION =
@@ -117,7 +117,7 @@ public class BraveTest {
 
   static String getVersionFromMaven(String path) throws Exception {
     InputStream is =
-        BraveTest.class.getResourceAsStream("/META-INF/maven/" + path + "/pom.properties");
+        ITBrave.class.getResourceAsStream("/META-INF/maven/" + path + "/pom.properties");
     Assert.assertNotNull(is);
     Properties p = new Properties();
     p.load(is);
@@ -125,7 +125,7 @@ public class BraveTest {
   }
 
   static String getBraveKarafVersion() throws Exception {
-    InputStream is = BraveTest.class.getResourceAsStream("/exam.properties");
+    InputStream is = ITBrave.class.getResourceAsStream("/exam.properties");
     Assert.assertNotNull(is);
     Properties p = new Properties();
     p.load(is);

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <zipkin-reporter.version>2.7.10</zipkin-reporter.version>
 
     <license-maven-plugin.version>2.11</license-maven-plugin.version>
-    <maven-failsafe-plugin.version>2.22.1</maven-failsafe-plugin.version>
+    <maven-failsafe-plugin.version>3.0.0-M3</maven-failsafe-plugin.version>
   </properties>
 
   <name>Brave Karaf (Parent)</name>
@@ -247,6 +247,15 @@
             </execution>
           </executions>
         </plugin>
+
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven-failsafe-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>${maven-failsafe-plugin.version}</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -285,15 +294,6 @@
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.1.0</version>
-      </plugin>
-
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>${maven-failsafe-plugin.version}</version>
-      </plugin>
-      <plugin>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <version>${maven-failsafe-plugin.version}</version>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
Common building and packaging shouldn't require execution of integration
tests. This renames the file so that it isn't executed when doing
`./mvnw package`

Thanks @shakuzen for the suggestion!