### PR TITLE
Addresses release feedback and updates build related versions

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Apache Zipkin Brave Karaf
+Copyright 2016-2019 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Apache Zipkin Brave Karaf
+Apache Zipkin (incubating) Brave Karaf
 Copyright 2016-2019 The Apache Software Foundation
 
 This product includes software developed at

--- a/pom.xml
+++ b/pom.xml
@@ -54,11 +54,11 @@
     <errorprone.version>2.3.2</errorprone.version>
 
     <!-- Make sure these versions match brave-bom -->
-    <brave.version>5.4.3</brave.version>
-    <zipkin.version>2.11.7</zipkin.version>
-    <zipkin-reporter.version>2.7.10</zipkin-reporter.version>
+    <brave.version>5.6.1</brave.version>
+    <zipkin.version>2.12.1</zipkin.version>
+    <zipkin-reporter.version>2.7.15</zipkin-reporter.version>
 
-    <license-maven-plugin.version>2.11</license-maven-plugin.version>
+    <license-maven-plugin.version>3.0</license-maven-plugin.version>
     <maven-failsafe-plugin.version>3.0.0-M3</maven-failsafe-plugin.version>
   </properties>
 
@@ -195,12 +195,12 @@
       <dependency>
         <groupId>org.awaitility</groupId>
         <artifactId>awaitility</artifactId>
-        <version>3.1.2</version>
+        <version>3.1.6</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>2.21.0</version>
+        <version>2.24.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -215,7 +215,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.10.0</version>
+      <version>3.11.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -238,7 +238,7 @@
         <plugin>
           <groupId>biz.aQute.bnd</groupId>
           <artifactId>bnd-maven-plugin</artifactId>
-          <version>4.0.0</version>
+          <version>4.1.0</version>
           <executions>
             <execution>
               <goals>
@@ -276,7 +276,7 @@
       <plugin>
         <groupId>net.orfjackal.retrolambda</groupId>
         <artifactId>retrolambda-maven-plugin</artifactId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -293,7 +293,7 @@
 
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
       </plugin>
 
       <plugin>
@@ -316,18 +316,15 @@
         </executions>
       </plugin>
 
-      <!-- Ensures checksums are added to published jars -->
       <plugin>
         <artifactId>maven-install-plugin</artifactId>
-        <version>2.5.2</version>
-        <configuration>
-          <createChecksum>true</createChecksum>
-        </configuration>
+        <version>3.0.0-M1</version>
       </plugin>
 
+      <!-- Uploads occur as a last step (which also adds checksums) -->
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.8.2</version>
+        <version>3.0.0-M1</version>
       </plugin>
 
       <plugin>
@@ -354,17 +351,12 @@
             <exclude>**/.idea/**</exclude>
             <exclude>LICENSE</exclude>
             <exclude>DISCLAIMER</exclude>
+            <exclude>NOTICE</exclude>
+            <exclude>Jenkinsfile</exclude>
             <exclude>**/*.md</exclude>
           </excludes>
           <strictCheck>true</strictCheck>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>com.mycila</groupId>
-            <artifactId>license-maven-plugin-git</artifactId>
-            <version>${license-maven-plugin.version}</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
This adds the missing NOTICE file and removes the git plugin from the
license check. Since we don't use a date expression in our headers, the
git plugin was unnecessarily fragile.

This also updates build related versions, leaving functional versions
alone (Karaf ones). They can be updated separately as sensitive to
itests.