### PR TITLE
Removes special casing from the NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -3,6 +3,3 @@ Copyright 2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
-
-Prior to Apache, source headers included the following notice:
-Copyright 2015-2018 The OpenZipkin Authors


### PR DESCRIPTION
After reviewing with others, I've found there is in fact no requirement for us, especially the original authors of the code, to be forced to add a line into the NOTICE file. Hence, I'm removing it.