### PR TITLE
Filters out maven wrapper from the source distribution

### DIFF
--- a/src/main/assemblies/source-release.xml
+++ b/src/main/assemblies/source-release.xml
@@ -25,7 +25,7 @@
     <format>zip</format>
   </formats>
 
-  <!-- Inlined.. patched from https://github.com/apache/maven-resources/blob/dfd6e72035380fc3bd573d55f0c5b77c903d6431/apache-source-release-assembly-descriptor/pom.xml -->
+  <!-- Inlined to exclude all maven wrapper artifacts. This allows us to avoid NOTICE citations -->
   <fileSets>
     <!-- main project directory structure -->
     <fileSet>
@@ -33,6 +33,11 @@
       <outputDirectory></outputDirectory>
       <useDefaultExcludes>true</useDefaultExcludes>
       <excludes>
+        <!-- PATCH: Maven wrapper -->
+        <exclude>.mvn/**</exclude>
+        <exclude>mvnw</exclude>
+        <exclude>mvnw.cmd</exclude>
+
         <!-- build output -->
         <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/).*${project.build.directory}.*]</exclude>
 
@@ -47,10 +52,6 @@
              or generate a project website, it's definitely possible that some
              of these files will be present. So, it's safer to exclude them.
         -->
-
-        <!-- PATCH: Maven wrapper binaries -->
-        <exclude>.mvn/wrapper/maven-wrapper.jar</exclude>
-        <exclude>.mvn/wrapper/MavenWrapperDownloader.class</exclude>
 
         <!-- IDEs -->
         <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?maven-eclipse\.xml]</exclude>


### PR DESCRIPTION
Maven doesn't strictly depend on the Takari wrapper. Excluding this
decouples us from ongoing discussions as to whether or not it is "nice"
or required to cite it in the NOTICE file.

See https://lists.apache.org/thread.html/26bbc663ce6f81125110234b30c1ddf63d4ab2a03da408bc9fe07563@%3Cgeneral.incubator.apache.org%3E
See https://issues.apache.org/jira/browse/MNG-5937