### PR TITLE
Works around inheritance that results in an empty DEPENDENCIES file

### DIFF
--- a/exporter-sender-kafka/pom.xml
+++ b/exporter-sender-kafka/pom.xml
@@ -62,6 +62,12 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-remote-resources-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-maven-plugin</artifactId>
       </plugin>

--- a/exporter-sender-okhttp/pom.xml
+++ b/exporter-sender-okhttp/pom.xml
@@ -57,6 +57,12 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-remote-resources-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-maven-plugin</artifactId>
       </plugin>

--- a/exporter/pom.xml
+++ b/exporter/pom.xml
@@ -61,6 +61,12 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-remote-resources-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-maven-plugin</artifactId>
       </plugin>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -41,6 +41,12 @@
     </resources>
     <plugins>
       <plugin>
+        <artifactId>maven-remote-resources-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -433,6 +433,22 @@
           </execution>
         </executions>
       </plugin>
+
+      <!-- org.apache:apache:21 sets maven-remote-resources-plugin in plugins, not pluginManagement
+           This results in execution in the parent project, and a side effect of an empty
+           DEPENDENCIES file in the assembly when packaged with the apache-release profile.
+
+           https://issues.apache.org/jira/browse/MPOM-218
+
+           This works around the problem by skipping at the parent level at the cost of having to
+           un-skip it at every deployed child.
+       -->
+      <plugin>
+        <artifactId>maven-remote-resources-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
org.apache:apache:21 sets maven-remote-resources-plugin in plugins, not pluginManagement
This results in execution in the parent project, and a side effect of an empty
DEPENDENCIES file in the assembly when packaged with the apache-release profile.

https://issues.apache.org/jira/browse/MPOM-218

This works around the problem by skipping at the parent level at the cost of having to
un-skip it at every deployed child.