### PR TITLE
Updates for new release

### DIFF
--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -1,22 +1,18 @@
 /*
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
-*/
-
+ * Copyright 2007-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import java.net.*;
 import java.io.*;
 import java.nio.channels.*;
@@ -24,11 +20,12 @@ import java.util.Properties;
 
 public class MavenWrapperDownloader {
 
+    private static final String WRAPPER_VERSION = "0.5.6";
     /**
      * Default URL to download the maven-wrapper.jar from, if no 'downloadUrl' is provided.
      */
-    private static final String DEFAULT_DOWNLOAD_URL =
-            "https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.4.2/maven-wrapper-0.4.2.jar";
+    private static final String DEFAULT_DOWNLOAD_URL = "https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/"
+        + WRAPPER_VERSION + "/maven-wrapper-" + WRAPPER_VERSION + ".jar";
 
     /**
      * Path to the maven-wrapper.properties file, which might contain a downloadUrl property to
@@ -76,13 +73,13 @@ public class MavenWrapperDownloader {
                 }
             }
         }
-        System.out.println("- Downloading from: : " + url);
+        System.out.println("- Downloading from: " + url);
 
         File outputFile = new File(baseDirectory.getAbsolutePath(), MAVEN_WRAPPER_JAR_PATH);
         if(!outputFile.getParentFile().exists()) {
             if(!outputFile.getParentFile().mkdirs()) {
                 System.out.println(
-                        "- ERROR creating output direcrory '" + outputFile.getParentFile().getAbsolutePath() + "'");
+                        "- ERROR creating output directory '" + outputFile.getParentFile().getAbsolutePath() + "'");
             }
         }
         System.out.println("- Downloading to: " + outputFile.getAbsolutePath());
@@ -98,6 +95,16 @@ public class MavenWrapperDownloader {
     }
 
     private static void downloadFileFromURL(String urlString, File destination) throws Exception {
+        if (System.getenv("MVNW_USERNAME") != null && System.getenv("MVNW_PASSWORD") != null) {
+            String username = System.getenv("MVNW_USERNAME");
+            char[] password = System.getenv("MVNW_PASSWORD").toCharArray();
+            Authenticator.setDefault(new Authenticator() {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication() {
+                    return new PasswordAuthentication(username, password);
+                }
+            });
+        }
         URL website = new URL(urlString);
         ReadableByteChannel rbc;
         rbc = Channels.newChannel(website.openStream());

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.0/apache-maven-3.6.0-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,21 @@
 # Run `travis lint` when changing this file to avoid breaking the build.
+dist: focal
+language: java
+# Intentionally don't use "jdk" key as it is coupled to jdk.java.net availability.
+addons:
+  apt:
+    update: true
 
 cache:
   directories:
-  - $HOME/.m2
-
-language: java
-
-jdk: openjdk11
+    - $HOME/.m2
 
 before_install:
+  # Use JDK 11, so we can release Java 6 bytecode
+  - export JAVA_VERSION=11
+  - sudo apt-get -y install openjdk-$JAVA_VERSION-jdk
+  - export JAVA_HOME=/usr/lib/jvm/java-$JAVA_VERSION-openjdk-amd64/
+  - ./mvnw -version
   # allocate commits to CI, not the owner of the deploy key
   - git config user.name "zipkinci"
   - git config user.email "zipkinci+zipkin-dev@googlegroups.com"
@@ -17,7 +24,8 @@ before_install:
   - echo "https://$GH_TOKEN:@github.com" > .git/credentials
 
 # Override default travis to use the maven wrapper; skip license on travis due to #1512
-install: ./mvnw install -DskipTests=true -Dlicense.skip=true -Dmaven.javadoc.skip=true -B -V
+# Use release profile to ensure
+install: ./mvnw install -DskipTests=true -Dlicense.skip=true -Dmaven.javadoc.skip=true -B -V -Prelease
 script: ./travis/publish.sh
 
 # Don't build release tags. This avoids publish conflicts because the version commit exists both on master and the release tag.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
-Brave for Apache Karaf sets up tracing components such that tools built with Karaf needn't configure these explicitly.
+Brave for Apache Karaf sets up tracing components such that tools built with Karaf needn't configure
+these explicitly.
 
 This repository includes OSGi services for tracing and reporting components.

--- a/exporter-sender-kafka/pom.xml
+++ b/exporter-sender-kafka/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2016-2019 The OpenZipkin Authors
+    Copyright 2016-2020 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave.karaf</groupId>
     <artifactId>brave-karaf-parent</artifactId>
-    <version>0.1.3-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -27,6 +27,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
+    <!-- Note: Kafka Clients minimum Java version is 1.8, so we release 1.8 -->
   </properties>
 
   <dependencies>

--- a/exporter-sender-kafka/src/main/java/io/zipkin/brave/exporter/sender/kafka/KafkaSenderExporter.java
+++ b/exporter-sender-kafka/src/main/java/io/zipkin/brave/exporter/sender/kafka/KafkaSenderExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -62,8 +62,7 @@ public class KafkaSenderExporter {
     return overrides;
   }
 
-  @Deactivate
-  public void deactive() {
+  @Deactivate public void deactive() {
     reg.unregister();
     sender.close();
   }

--- a/exporter-sender-kafka/src/test/java/io/zipkin/brave/exporter/sender/kafka/KafkaSenderExporterTest.java
+++ b/exporter-sender-kafka/src/test/java/io/zipkin/brave/exporter/sender/kafka/KafkaSenderExporterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -26,8 +26,7 @@ import static org.mockito.Mockito.when;
 @Config(bootstrapServers = "server1", messageMaxBytes = 10, topic = "mytopic")
 public class KafkaSenderExporterTest {
 
-  @Test
-  public void testConfig() {
+  @Test public void testConfig() {
     KafkaSenderExporter exporter = new KafkaSenderExporter();
     Map<String, String> properties = new HashMap<String, String>();
     properties.put("kafka.myprop", "myvalue");

--- a/exporter-sender-okhttp/pom.xml
+++ b/exporter-sender-okhttp/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2016-2019 The OpenZipkin Authors
+    Copyright 2016-2020 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.brave.karaf</groupId>
     <artifactId>brave-karaf-parent</artifactId>
-    <version>0.1.3-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -27,6 +27,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
+    <!-- Note: after OkHttp 3.12.12, the minimum Java version is 1.8, so we release 1.8 -->
   </properties>
 
   <dependencies>
@@ -53,12 +54,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <artifactId>maven-remote-resources-plugin</artifactId>
-        <configuration>
-          <skip>false</skip>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-maven-plugin</artifactId>

--- a/exporter-sender-okhttp/src/main/java/io/zipkin/brave/exporter/sender/okhttp/SenderOkHttpExporter.java
+++ b/exporter-sender-okhttp/src/main/java/io/zipkin/brave/exporter/sender/okhttp/SenderOkHttpExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/exporter/pom.xml
+++ b/exporter/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2016-2019 The OpenZipkin Authors
+    Copyright 2016-2020 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -14,11 +14,13 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>io.zipkin.brave.karaf</groupId>
     <artifactId>brave-karaf-parent</artifactId>
-    <version>0.1.3-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -50,6 +52,18 @@
       <artifactId>brave-instrumentation-http</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave-instrumentation-messaging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave-instrumentation-rpc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.reporter2</groupId>
+      <artifactId>zipkin-reporter-brave</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.zipkin.reporter2</groupId>
       <artifactId>zipkin-sender-urlconnection</artifactId>
     </dependency>
@@ -72,4 +86,39 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <properties>
+        <!-- OSGi is minimum 1.5, but the main jar is minimal Java 1.6 bytecode due to Brave -->
+        <main.java.version>1.6</main.java.version>
+        <main.signature.artifact>java16</main.signature.artifact>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>enforce-java</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <!-- JDK 12+ can no longer generate Java 1.6 bytecode, so we require JDK 11.
+                         https://www.oracle.com/java/technologies/javase/12-relnote-issues.html -->
+                    <requireJavaVersion>
+                      <version>[11,12)</version>
+                    </requireJavaVersion>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/exporter/src/main/java/io/zipkin/brave/exporter/MessagingTracingExporter.java
+++ b/exporter/src/main/java/io/zipkin/brave/exporter/MessagingTracingExporter.java
@@ -14,7 +14,7 @@
 package io.zipkin.brave.exporter;
 
 import brave.Tracing;
-import brave.http.HttpTracing;
+import brave.messaging.MessagingTracing;
 import java.util.Hashtable;
 import java.util.Map;
 import org.osgi.framework.BundleContext;
@@ -26,22 +26,22 @@ import org.osgi.service.component.annotations.Reference;
 
 @Component(
     immediate = true,
-    name = "io.zipkin.brave.http"
+    name = "io.zipkin.brave.messaging"
 )
-public class HttpTracingExporter {
+public class MessagingTracingExporter {
   @Reference Tracing tracing;
 
-  private HttpTracing httpTracing;
-  private ServiceRegistration<HttpTracing> reg;
+  private MessagingTracing messagingTracing;
+  private ServiceRegistration<MessagingTracing> reg;
 
   @Activate public void activate(BundleContext context, Map<String, String> properties) {
-    httpTracing = HttpTracing.newBuilder(tracing).build();
-    reg = context.registerService(HttpTracing.class, httpTracing,
+    messagingTracing = MessagingTracing.newBuilder(tracing).build();
+    reg = context.registerService(MessagingTracing.class, messagingTracing,
         new Hashtable<String, String>(properties));
   }
 
   @Deactivate public void deactive() {
     reg.unregister();
-    if (httpTracing != null) httpTracing.close();
+    if (messagingTracing != null) messagingTracing.close();
   }
 }

--- a/exporter/src/main/java/io/zipkin/brave/exporter/TracingExporter.java
+++ b/exporter/src/main/java/io/zipkin/brave/exporter/TracingExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,8 +14,10 @@
 package io.zipkin.brave.exporter;
 
 import brave.Tracing;
-import brave.sampler.Sampler;
+import brave.handler.SpanHandler;
+import brave.sampler.RateLimitingSampler;
 import java.util.Hashtable;
+import java.util.List;
 import java.util.Map;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
@@ -23,10 +25,9 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
-import zipkin2.Span;
-import zipkin2.reporter.Reporter;
 
 @Component(
     immediate = true,
@@ -34,35 +35,38 @@ import zipkin2.reporter.Reporter;
 )
 @Designate(ocd = TracingExporter.Config.class)
 public class TracingExporter {
-  @Reference
-  Reporter<Span> reporter;
+  @Reference(cardinality = ReferenceCardinality.AT_LEAST_ONE) List<SpanHandler> spanHandlers;
 
   private Tracing tracing;
   private ServiceRegistration<Tracing> reg;
 
   @Activate
   public void activate(Config config, BundleContext context, Map<String, String> properties) {
-    tracing = Tracing.newBuilder()
-        .localServiceName(config.name())
-        .spanReporter(reporter)
+    Tracing.Builder builder = Tracing.newBuilder()
+        .localServiceName(config.localServiceName())
+        .supportsJoin(config.supportsJoin())
         .traceId128Bit(config.traceId128Bit())
-        .sampler(Sampler.create(config.rate()))
-        .build();
+        .sampler(RateLimitingSampler.create(config.tracesPerSecond()));
+    for (SpanHandler spanHandler : spanHandlers) {
+      builder.addSpanHandler(spanHandler);
+    }
+    tracing = builder.build();
     reg =
         context.registerService(Tracing.class, tracing, new Hashtable<String, String>(properties));
   }
 
-  @Deactivate
-  public void deactive() {
+  @Deactivate public void deactive() {
     reg.unregister();
     if (tracing != null) tracing.close();
   }
 
   public static @ObjectClassDefinition(name = "Tracing") @interface Config {
-    String name() default "unknown";
+    String localServiceName() default "unknown";
+
+    boolean supportsJoin() default true;
 
     boolean traceId128Bit() default false;
 
-    float rate() default 1;
+    int tracesPerSecond() default 10;
   }
 }

--- a/exporter/src/main/java/io/zipkin/brave/exporter/sender/urlconnection/URLConnectionSenderExporter.java
+++ b/exporter/src/main/java/io/zipkin/brave/exporter/sender/urlconnection/URLConnectionSenderExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -48,13 +48,12 @@ public class URLConnectionSenderExporter {
     reg = context.registerService(Sender.class, sender, new Hashtable<String, String>(properties));
   }
 
-  @Deactivate
-  public void deactive() {
+  @Deactivate public void deactive() {
     reg.unregister();
     if (sender != null) sender.close();
   }
 
-  public static @ObjectClassDefinition(name = "Zipkin Sender URLConnection") @interface Config {
+  public @ObjectClassDefinition(name = "Zipkin Sender URLConnection") @interface Config {
     String endpoint() default "http://localhost:9411/api/v2/spans";
 
     boolean compressionEnabled() default true;

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2019 The OpenZipkin Authors
+    Copyright 2016-2020 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -19,8 +19,7 @@
   <parent>
     <groupId>io.zipkin.brave.karaf</groupId>
     <artifactId>brave-karaf-parent</artifactId>
-    <version>0.1.3-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>brave-features</artifactId>
   <packaging>pom</packaging>
@@ -39,6 +38,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
+        <version>3.2.0</version>
         <executions>
           <execution>
             <id>filter</id>

--- a/features/src/main/resources/features.xml
+++ b/features/src/main/resources/features.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2019 The OpenZipkin Authors
+    Copyright 2016-2020 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -22,15 +22,18 @@
 		<feature>scr</feature>
 		<bundle dependency="true">mvn:io.zipkin.zipkin2/zipkin/${zipkin.version}</bundle>
 		<bundle dependency="true">mvn:io.zipkin.reporter2/zipkin-reporter/${zipkin-reporter.version}</bundle>
+		<bundle dependency="true">mvn:io.zipkin.reporter2/zipkin-reporter-brave/${zipkin-reporter.version}</bundle>
 		<bundle>mvn:io.zipkin.reporter2/zipkin-sender-urlconnection/${zipkin-reporter.version}</bundle>
 		<bundle>mvn:io.zipkin.brave/brave/${brave.version}</bundle>
 		<bundle>mvn:io.zipkin.brave/brave-instrumentation-http/${brave.version}</bundle>
+		<bundle>mvn:io.zipkin.brave/brave-instrumentation-messaging/${brave.version}</bundle>
+		<bundle>mvn:io.zipkin.brave/brave-instrumentation-rpc/${brave.version}</bundle>
 		<bundle>mvn:io.zipkin.brave.karaf/brave-exporter/${project.version}</bundle>
 	</feature>
 
 	<feature name="brave-sender-kafka">
 		<feature>brave</feature>
-		<bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kafka-clients/2.2.0_1</bundle>
+		<bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kafka-clients/2.6.0_1</bundle>
 		<bundle>mvn:io.zipkin.reporter2/zipkin-sender-kafka/${zipkin-reporter.version}</bundle>
 		<bundle>mvn:io.zipkin.brave.karaf/brave-exporter-sender-kafka/${project.version}</bundle>
 	</feature>
@@ -38,6 +41,7 @@
 	<feature name="brave-sender-okhttp">
 		<feature>brave</feature>
 		<bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okio/1.15.0_1</bundle>
+		<!-- 3.14.1_1 was the last version of OkHttp v3. We can decide to update this to 4 later, which needs Kotlin -->
 		<bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okhttp/3.14.1_1</bundle>
 		<!-- for javax.annotation.Nullable used by OkHttp. Lacking this is a problem in JDK 11 -->
 		<bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jsr305/3.0.2_1</bundle>

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2019 The OpenZipkin Authors
+    Copyright 2016-2020 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -19,14 +19,13 @@
   <parent>
     <groupId>io.zipkin.brave.karaf</groupId>
     <artifactId>brave-karaf-parent</artifactId>
-    <version>0.1.3-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>brave-itests</artifactId>
 
   <properties>
-    <pax-exam.version>4.12.0</pax-exam.version>
-    <karaf.version>4.2.1</karaf.version>
+    <pax-exam.version>4.13.4</pax-exam.version>
+    <karaf.version>4.2.10</karaf.version>
     <main.basedir>${project.basedir}/..</main.basedir>
   </properties>
 

--- a/itests/src/test/java/io/zipkin/brave/itests/ITBrave.java
+++ b/itests/src/test/java/io/zipkin/brave/itests/ITBrave.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,20 +13,18 @@
  */
 package io.zipkin.brave.itests;
 
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.cm.ConfigurationAdminOptions.newConfiguration;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
-
+import brave.Tracing;
+import brave.handler.SpanHandler;
+import brave.http.HttpTracing;
+import brave.messaging.MessagingTracing;
+import brave.rpc.RpcTracing;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Properties;
 import javax.inject.Inject;
-
-import org.junit.Assert;
+import org.junit.ComparisonFailure;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
@@ -39,23 +37,26 @@ import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
-
 import zipkin2.reporter.Sender;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.ops4j.pax.exam.CoreOptions.maven;
+import static org.ops4j.pax.exam.cm.ConfigurationAdminOptions.newConfiguration;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 public class ITBrave {
-  private static final String FILTER_KAFKA = "(component.name=io.zipkin.sender.kafka)";
-  private static final String FILTER_OKHTTP = "(component.name=io.zipkin.sender.okhttp)";
-  private static final String FILTER_URLCONNECTION =
-      "(component.name=io.zipkin.sender.urlconnection)";
   private static final long TIMEOUT = 10000;
 
-  @Inject
-  BundleContext context;
+  @Inject BundleContext context;
 
-  @Configuration
-  public static Option[] configuration() throws Exception {
+  @Configuration public static Option[] configuration() throws Exception {
     MavenArtifactUrlReference karaf = maven().groupId("org.apache.karaf").artifactId("apache-karaf")
         .type("zip")
         .version(getVersionFromMaven("org.apache.karaf.features/org.apache.karaf.features.core"));
@@ -71,61 +72,111 @@ public class ITBrave {
         // Create an empty config to trigger creation of component
         newConfiguration("io.zipkin.sender.urlconnection").asOption(),
         newConfiguration("io.zipkin.sender.okhttp").asOption(),
-        newConfiguration("io.zipkin.sender.kafka").asOption()
+        newConfiguration("io.zipkin.sender.kafka").asOption(),
+        newConfiguration("io.zipkin.brave").asOption(),
+        newConfiguration("io.zipkin.brave.asynczipkinspanhandler").asOption(),
+        newConfiguration("io.zipkin.brave.http").asOption(),
+        newConfiguration("io.zipkin.brave.messaging").asOption(),
+        newConfiguration("io.zipkin.brave.rpc").asOption()
     };
   }
 
-  @Test
-  public void checkSenderUrlConnection() {
-    ServiceReference<Sender> ref = getSingleSender(FILTER_URLCONNECTION);
-    Assert.assertEquals(10000, ref.getProperty("connectTimeout"));
+  @Test public void checkSenderUrlConnection() {
+    ServiceReference<Sender> ref =
+        getSingle(Sender.class, "(component.name=io.zipkin.sender.urlconnection)");
+
+    assertPropertyEquals(ref, "endpoint", "http://localhost:9411/api/v2/spans");
+    assertPropertyEquals(ref, "connectTimeout", 10000);
   }
 
-  @Test
-  public void checkSenderKafka() {
-    ServiceReference<Sender> ref = getSingleSender(FILTER_KAFKA);
-    Assert.assertEquals("zipkin", ref.getProperty("topic"));
+  @Test public void checkSenderKafka() {
+    ServiceReference<Sender> ref =
+        getSingle(Sender.class, "(component.name=io.zipkin.sender.kafka)");
+
+    assertPropertyEquals(ref, "topic", "zipkin");
   }
 
-  @Test
-  public void checkSenderOkHttp() {
-    ServiceReference<Sender> ref = getSingleSender(FILTER_OKHTTP);
-    Assert.assertEquals("http://localhost:9411/api/v2/spans", ref.getProperty("endpoint"));
+  @Test public void checkSenderOkHttp() {
+    ServiceReference<Sender> ref =
+        getSingle(Sender.class, "(component.name=io.zipkin.sender.okhttp)");
+
+    assertPropertyEquals(ref, "endpoint", "http://localhost:9411/api/v2/spans");
   }
 
-  private ServiceReference<Sender> getSingleSender(String filter) {
-	  long startTime = System.currentTimeMillis();
-	  while (System.currentTimeMillis() - startTime < TIMEOUT) {
-		  try {
-			  Collection<ServiceReference<Sender>> allRefs = context.getServiceReferences(Sender.class, null);
-			  System.out.println(allRefs);
-			  Collection<ServiceReference<Sender>> refs = context.getServiceReferences(Sender.class, filter);
-			  if (refs.size() >= 1) {
-				  Assert.assertEquals(1, refs.size());
-				  return refs.iterator().next();
-			  }
-			  Thread.sleep(100);
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	  }
-	  throw new RuntimeException("Timeout finding service");
+  @Test public void checkZipkinSpanHandler() {
+    getSingle(SpanHandler.class, "(component.name=io.zipkin.brave.asynczipkinspanhandler)");
+  }
+
+  @Test public void checkTracing() {
+    ServiceReference<Tracing> ref = getSingle(Tracing.class, "(component.name=io.zipkin.brave)");
+
+    assertPropertyEquals(ref, "tracesPerSecond", 10);
+
+    // It is hard to tell things are configured correctly, except to instantiate the tracer.
+    try (Tracing tracing = context.getService(ref)) {
+      // Check the span handler actually plumbed. We can't check the type specifically as the test
+      // creates many senders, and we don't prioritize which is chosen on conflict.
+      //
+      // NOTE: This will drift when AsyncZipkinSpanHandler fixes its toString!
+      assertTrue(tracing.toString().startsWith("Tracer{spanHandler=AsyncReporter"));
+    }
+  }
+
+  @Test public void checkHttpTracing() {
+    getSingle(HttpTracing.class, "(component.name=io.zipkin.brave.http)");
+  }
+
+  @Test public void checkMessagingTracing() {
+    getSingle(MessagingTracing.class, "(component.name=io.zipkin.brave.messaging)");
+  }
+
+  @Test public void checkRpcTracing() {
+    getSingle(RpcTracing.class, "(component.name=io.zipkin.brave.rpc)");
+  }
+
+  <T> ServiceReference<T> getSingle(Class<T> type, String filter) {
+    long startTime = System.currentTimeMillis();
+    while (System.currentTimeMillis() - startTime < TIMEOUT) {
+      try {
+        Collection<ServiceReference<T>> refs = context.getServiceReferences(type, filter);
+        if (refs.size() >= 1) {
+          assertEquals(1, refs.size());
+          return refs.iterator().next();
+        }
+        Collection<ServiceReference<T>> allRefs = context.getServiceReferences(type, null);
+        if (!allRefs.isEmpty()) {
+          System.out.println("filter: " + filter + " didn't match " + allRefs);
+        }
+        Thread.sleep(100);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+    throw new RuntimeException("Timeout finding service: " + filter);
   }
 
   static String getVersionFromMaven(String path) throws Exception {
-    InputStream is =
-        ITBrave.class.getResourceAsStream("/META-INF/maven/" + path + "/pom.properties");
-    Assert.assertNotNull(is);
     Properties p = new Properties();
-    p.load(is);
+    try (InputStream is = ITBrave.class.getResourceAsStream(
+        "/META-INF/maven/" + path + "/pom.properties")) {
+      p.load(is);
+    }
     return p.getProperty("version");
   }
 
   static String getBraveKarafVersion() throws Exception {
-    InputStream is = ITBrave.class.getResourceAsStream("/exam.properties");
-    Assert.assertNotNull(is);
     Properties p = new Properties();
-    p.load(is);
+    try (InputStream is = ITBrave.class.getResourceAsStream("/exam.properties")) {
+      p.load(is);
+    }
     return p.getProperty("brave-karaf.version");
+  }
+
+  static void assertPropertyEquals(ServiceReference<?> ref, String key, Object value) {
+    List<String> propertyKeys = Arrays.asList(ref.getPropertyKeys());
+    if (!propertyKeys.contains(key)) {
+      throw new ComparisonFailure("Expected propertyKey", key, propertyKeys.toString());
+    }
+    assertEquals(value, ref.getProperty(key));
   }
 }

--- a/mvnw
+++ b/mvnw
@@ -19,7 +19,7 @@
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# Maven2 Start Up Batch script
+# Maven Start Up Batch script
 #
 # Required ENV vars:
 # ------------------
@@ -114,7 +114,6 @@ if $mingw ; then
     M2_HOME="`(cd "$M2_HOME"; pwd)`"
   [ -n "$JAVA_HOME" ] &&
     JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
-  # TODO classpath?
 fi
 
 if [ -z "$JAVA_HOME" ]; then
@@ -212,7 +211,11 @@ else
     if [ "$MVNW_VERBOSE" = true ]; then
       echo "Couldn't find .mvn/wrapper/maven-wrapper.jar, downloading it ..."
     fi
-    jarUrl="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.4.2/maven-wrapper-0.4.2.jar"
+    if [ -n "$MVNW_REPOURL" ]; then
+      jarUrl="$MVNW_REPOURL/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
+    else
+      jarUrl="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
+    fi
     while IFS="=" read key value; do
       case "$key" in (wrapperUrl) jarUrl="$value"; break ;;
       esac
@@ -221,22 +224,38 @@ else
       echo "Downloading from: $jarUrl"
     fi
     wrapperJarPath="$BASE_DIR/.mvn/wrapper/maven-wrapper.jar"
+    if $cygwin; then
+      wrapperJarPath=`cygpath --path --windows "$wrapperJarPath"`
+    fi
 
     if command -v wget > /dev/null; then
         if [ "$MVNW_VERBOSE" = true ]; then
           echo "Found wget ... using wget"
         fi
-        wget "$jarUrl" -O "$wrapperJarPath"
+        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+            wget "$jarUrl" -O "$wrapperJarPath"
+        else
+            wget --http-user=$MVNW_USERNAME --http-password=$MVNW_PASSWORD "$jarUrl" -O "$wrapperJarPath"
+        fi
     elif command -v curl > /dev/null; then
         if [ "$MVNW_VERBOSE" = true ]; then
           echo "Found curl ... using curl"
         fi
-        curl -o "$wrapperJarPath" "$jarUrl"
+        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+            curl -o "$wrapperJarPath" "$jarUrl" -f
+        else
+            curl --user $MVNW_USERNAME:$MVNW_PASSWORD -o "$wrapperJarPath" "$jarUrl" -f
+        fi
+
     else
         if [ "$MVNW_VERBOSE" = true ]; then
           echo "Falling back to using Java to download"
         fi
         javaClass="$BASE_DIR/.mvn/wrapper/MavenWrapperDownloader.java"
+        # For Cygwin, switch paths to Windows format before running javac
+        if $cygwin; then
+          javaClass=`cygpath --path --windows "$javaClass"`
+        fi
         if [ -e "$javaClass" ]; then
             if [ ! -e "$BASE_DIR/.mvn/wrapper/MavenWrapperDownloader.class" ]; then
                 if [ "$MVNW_VERBOSE" = true ]; then
@@ -276,6 +295,11 @@ if $cygwin; then
   [ -n "$MAVEN_PROJECTBASEDIR" ] &&
     MAVEN_PROJECTBASEDIR=`cygpath --path --windows "$MAVEN_PROJECTBASEDIR"`
 fi
+
+# Provide a "standardized" way to retrieve the CLI args that will
+# work with both Windows and non-Windows executions.
+MAVEN_CMD_LINE_ARGS="$MAVEN_CONFIG $@"
+export MAVEN_CMD_LINE_ARGS
 
 WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -18,7 +18,7 @@
 @REM ----------------------------------------------------------------------------
 
 @REM ----------------------------------------------------------------------------
-@REM Maven2 Start Up Batch script
+@REM Maven Start Up Batch script
 @REM
 @REM Required ENV vars:
 @REM JAVA_HOME - location of a JDK home dir
@@ -26,7 +26,7 @@
 @REM Optional ENV vars
 @REM M2_HOME - location of maven2's installed home dir
 @REM MAVEN_BATCH_ECHO - set to 'on' to enable the echoing of the batch commands
-@REM MAVEN_BATCH_PAUSE - set to 'on' to wait for a key stroke before ending
+@REM MAVEN_BATCH_PAUSE - set to 'on' to wait for a keystroke before ending
 @REM MAVEN_OPTS - parameters passed to the Java VM when running Maven
 @REM     e.g. to debug Maven itself, use
 @REM set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
@@ -37,7 +37,7 @@
 @echo off
 @REM set title of command window
 title %0
-@REM enable echoing my setting MAVEN_BATCH_ECHO to 'on'
+@REM enable echoing by setting MAVEN_BATCH_ECHO to 'on'
 @if "%MAVEN_BATCH_ECHO%" == "on"  echo %MAVEN_BATCH_ECHO%
 
 @REM set %HOME% to equivalent of $HOME
@@ -120,22 +120,43 @@ SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
 set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
 set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
-set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.4.2/maven-wrapper-0.4.2.jar"
-FOR /F "tokens=1,2 delims==" %%A IN (%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties) DO (
-	IF "%%A"=="wrapperUrl" SET DOWNLOAD_URL=%%B 
+set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
+
+FOR /F "tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
+    IF "%%A"=="wrapperUrl" SET DOWNLOAD_URL=%%B
 )
 
 @REM Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
 @REM This allows using the maven wrapper in projects that prohibit checking in binary data.
 if exist %WRAPPER_JAR% (
-    echo Found %WRAPPER_JAR%
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Found %WRAPPER_JAR%
+    )
 ) else (
-    echo Couldn't find %WRAPPER_JAR%, downloading it ...
-	echo Downloading from: %DOWNLOAD_URL%
-    powershell -Command "(New-Object Net.WebClient).DownloadFile('%DOWNLOAD_URL%', '%WRAPPER_JAR%')"
-    echo Finished downloading %WRAPPER_JAR%
+    if not "%MVNW_REPOURL%" == "" (
+        SET DOWNLOAD_URL="%MVNW_REPOURL%/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
+    )
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Couldn't find %WRAPPER_JAR%, downloading it ...
+        echo Downloading from: %DOWNLOAD_URL%
+    )
+
+    powershell -Command "&{"^
+		"$webclient = new-object System.Net.WebClient;"^
+		"if (-not ([string]::IsNullOrEmpty('%MVNW_USERNAME%') -and [string]::IsNullOrEmpty('%MVNW_PASSWORD%'))) {"^
+		"$webclient.Credentials = new-object System.Net.NetworkCredential('%MVNW_USERNAME%', '%MVNW_PASSWORD%');"^
+		"}"^
+		"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $webclient.DownloadFile('%DOWNLOAD_URL%', '%WRAPPER_JAR%')"^
+		"}"
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Finished downloading %WRAPPER_JAR%
+    )
 )
 @REM End of extension
+
+@REM Provide a "standardized" way to retrieve the CLI args that will
+@REM work with both Windows and non-Windows executions.
+set MAVEN_CMD_LINE_ARGS=%*
 
 %MAVEN_JAVA_EXE% %JVM_CONFIG_MAVEN_PROPS% %MAVEN_OPTS% %MAVEN_DEBUG_OPTS% -classpath %WRAPPER_JAR% "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" %WRAPPER_LAUNCHER% %MAVEN_CONFIG% %*
 if ERRORLEVEL 1 goto error

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2019 The OpenZipkin Authors
+    Copyright 2016-2020 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -19,7 +19,7 @@
 
   <groupId>io.zipkin.brave.karaf</groupId>
   <artifactId>brave-karaf-parent</artifactId>
-  <version>0.1.3-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -34,23 +34,25 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 
-    <!-- default bytecode version for src/main -->
-    <main.java.version>1.6</main.java.version>
-    <main.signature.artifact>java16</main.signature.artifact>
+    <!-- default bytecode version main and test sources, overridden per project on release -->
+    <main.java.version>1.8</main.java.version>
+    <main.signature.artifact>java18</main.signature.artifact>
 
     <main.basedir>${project.basedir}</main.basedir>
 
     <!-- override to set exclusions per-project -->
     <errorprone.args />
-    <errorprone.version>2.3.2</errorprone.version>
+    <errorprone.version>2.4.0</errorprone.version>
+    <javac.version>9+181-r4173-1</javac.version>
 
     <!-- Make sure these versions match brave-bom -->
-    <brave.version>5.6.5</brave.version>
-    <zipkin.version>2.14.2</zipkin.version>
-    <zipkin-reporter.version>2.8.4</zipkin-reporter.version>
+    <brave.version>5.12.7</brave.version>
+    <zipkin.version>2.22.0</zipkin.version>
+    <zipkin-reporter.version>2.15.2</zipkin-reporter.version>
 
-    <license-maven-plugin.version>3.0</license-maven-plugin.version>
-    <maven-failsafe-plugin.version>3.0.0-M3</maven-failsafe-plugin.version>
+    <!-- TODO: cleanup any redundant ignores now also in the 4.0 release (once final) -->
+    <license-maven-plugin.version>4.0.rc2</license-maven-plugin.version>
+    <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
   </properties>
 
   <name>Brave Karaf (Parent)</name>
@@ -132,6 +134,11 @@
       </dependency>
       <dependency>
         <groupId>io.zipkin.reporter2</groupId>
+        <artifactId>zipkin-reporter-brave</artifactId>
+        <version>${zipkin-reporter.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.zipkin.reporter2</groupId>
         <artifactId>zipkin-sender-urlconnection</artifactId>
         <version>${zipkin-reporter.version}</version>
       </dependency>
@@ -155,6 +162,16 @@
         <artifactId>brave-instrumentation-http</artifactId>
         <version>${brave.version}</version>
       </dependency>
+      <dependency>
+        <groupId>io.zipkin.brave</groupId>
+        <artifactId>brave-instrumentation-messaging</artifactId>
+        <version>${brave.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.zipkin.brave</groupId>
+        <artifactId>brave-instrumentation-rpc</artifactId>
+        <version>${brave.version}</version>
+      </dependency>
 
       <dependency>
         <groupId>org.osgi</groupId>
@@ -170,12 +187,12 @@
       <dependency>
         <groupId>org.awaitility</groupId>
         <artifactId>awaitility</artifactId>
-        <version>3.1.6</version>
+        <version>4.0.3</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>2.24.0</version>
+        <version>3.5.15</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -184,13 +201,13 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.12.1</version>
+      <version>3.17.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -208,16 +225,16 @@
         <plugin>
           <groupId>io.takari</groupId>
           <artifactId>maven</artifactId>
-          <version>0.7.6</version>
+          <version>0.7.7</version>
           <configuration>
-            <maven>3.6.1</maven>
+            <maven>3.6.3</maven>
           </configuration>
         </plugin>
 
         <plugin>
           <groupId>biz.aQute.bnd</groupId>
           <artifactId>bnd-maven-plugin</artifactId>
-          <version>4.1.0</version>
+          <version>5.2.0</version>
           <executions>
             <execution>
               <goals>
@@ -240,7 +257,7 @@
 
         <plugin>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.3</version>
+          <version>3.0.0-M1</version>
           <configuration>
             <useReleaseProfile>false</useReleaseProfile>
             <releaseProfiles>release</releaseProfiles>
@@ -262,58 +279,48 @@
 
     <plugins>
       <plugin>
-        <inherited>true</inherited>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
+        <inherited>true</inherited>
         <configuration>
-          <!-- Retrolambda will rewrite lambdas as Java 6 bytecode -->
-          <source>1.8</source>
-          <target>1.8</target>
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
+          <source>${main.java.version}</source>
+          <target>${main.java.version}</target>
+          <fork>true</fork>
           <showWarnings>true</showWarnings>
         </configuration>
       </plugin>
 
       <plugin>
-        <groupId>net.orfjackal.retrolambda</groupId>
-        <artifactId>retrolambda-maven-plugin</artifactId>
-        <version>2.5.6</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>process-main</goal>
-            </goals>
-            <configuration>
-              <target>${main.java.version}</target>
-              <fork>true</fork>
-              <quiet>true</quiet>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>3.2.0</version>
       </plugin>
 
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven-failsafe-plugin.version}</version>
+        <configuration>
+          <!-- Ensure scope leak cause ends up in the console -->
+          <trimStackTrace>false</trimStackTrace>
+        </configuration>
       </plugin>
+
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>${maven-failsafe-plugin.version}</version>
+        <configuration>
+          <!-- Try to prevent flakes in CI -->
+          <reuseForks>false</reuseForks>
+          <!-- workaround to SUREFIRE-1831 -->
+          <useModulePath>false</useModulePath>
+          <!-- Ensure scope leak cause ends up in the console -->
+          <trimStackTrace>false</trimStackTrace>
+        </configuration>
         <executions>
           <execution>
             <id>integration-test</id>
+            <phase>verify</phase>
             <goals>
               <goal>integration-test</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>verify</id>
-            <goals>
               <goal>verify</goal>
             </goals>
           </execution>
@@ -323,7 +330,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.17</version>
+        <version>1.19</version>
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>
@@ -381,7 +388,7 @@
 
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M2</version>
+        <version>3.0.0-M3</version>
         <executions>
           <execution>
             <id>enforce-java</id>
@@ -391,7 +398,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[11,13)</version>
+                  <version>[11,16)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>
@@ -402,41 +409,6 @@
   </build>
 
   <profiles>
-    <profile>
-      <id>error-prone-1.8</id>
-      <activation>
-        <jdk>1.8</jdk>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <!-- running errorprone even on test tree to avoid
-                 java.lang.NoSuchFieldError: ANNOTATION_PROCESSOR_MODULE_PATH compiling tests -->
-            <configuration>
-              <compilerId>javac-with-errorprone</compilerId>
-              <forceJavacCompilerUse>true</forceJavacCompilerUse>
-              <compilerArgs>
-                <arg>${errorprone.args}</arg>
-              </compilerArgs>
-            </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                <version>2.8.5</version>
-              </dependency>
-              <dependency>
-                <groupId>com.google.errorprone</groupId>
-                <artifactId>error_prone_core</artifactId>
-                <version>${errorprone.version}</version>
-              </dependency>
-            </dependencies>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
     <profile>
       <id>error-prone-9+</id>
       <activation>
@@ -479,10 +451,31 @@
       <id>release</id>
       <build>
         <plugins>
+          <plugin>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>enforce-java</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <!-- JDK 12+ can no longer generate Java 1.6 bytecode, so we require JDK 11.
+                         https://www.oracle.com/java/technologies/javase/12-relnote-issues.html -->
+                    <requireJavaVersion>
+                      <version>[11,12)</version>
+                    </requireJavaVersion>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
           <!-- Creates source jar -->
           <plugin>
             <artifactId>maven-source-plugin</artifactId>
-            <version>3.1.0</version>
+            <version>3.2.1</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
@@ -495,11 +488,13 @@
 
           <plugin>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.1.0</version>
+            <version>3.2.0</version>
             <configuration>
               <failOnError>false</failOnError>
               <!-- hush pedantic warnings: we don't put param and return on everything! -->
               <doclint>none</doclint>
+              <!-- While we publish modules, our source is pre-Java9 so tell javadoc that. -->
+              <source>8</source>
             </configuration>
             <executions>
               <execution>

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2019 The OpenZipkin Authors
+# Copyright 2016-2020 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -113,8 +113,8 @@ if ! is_pull_request && build_started_by_tag; then
   check_release_tag
 fi
 
-# skip license on travis due to #1512
-./mvnw install -nsu -Dlicense.skip=true
+# skip license on travis due to #1512, ensure nothing in release profile will fail
+./mvnw install -nsu -Dlicense.skip=true -Prelease
 
 # If we are on a pull request, our only job is to run tests, which happened above via ./mvnw install
 if is_pull_request; then


### PR DESCRIPTION
This adds missing messaging and RPC components. It also changes the following
as the former we misleading and not conventional.

* Tracing.service -> Tracing.localServiceName
* Tracing.rate=1 (was a percentage) -> Tracing.tracesPerSecond=10

It also adds

* Tracing.traceId128Bit needed for some emulators

In general the build has been refreshed and some missing tests backfilled.

I've updated to v0.2 as the two properties above are breaking changes.