### PR TITLE
Re-enables license plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ arch: arm64           # LXD container based build for OSS only
 os: linux             # required for arch different than amd64
 dist: focal           # newest available distribution
 
-# Don't do a shallow clone to allow license plugin to correctly read git history.
+# license-maven-plugin needs the full history to generate copyright year range. Ex. 2013-2020
+# Don't do a shallow clone, as it interferes with this.
 git:
   depth: false
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,8 +14,13 @@ This repo uses semantic versions. Please keep this in mind when choosing version
 
 1. **Wait for Travis CI**
 
-   This part is controlled by [`travis/publish.sh`](travis/publish.sh). It creates a bunch of new commits, bumps
-   the version, publishes artifacts and syncs to Maven Central.
+   Release automation invokes [`travis/publish.sh`](travis/publish.sh), which does the following:
+     * Creates commits, N.N.N tag, and increments the version (maven-release-plugin)
+     * Publishes jars to https://oss.sonatype.org/service/local/staging/deploy/maven2 (maven-deploy-plugin)
+       * Upon close, this synchronizes jars to Maven Central (nexus-staging-maven-plugin)
+
+   Notes:
+     * https://search.maven.org/ index will take longer than direct links like https://repo1.maven.org/maven2/io/zipkin
 
 ## Credentials
 
@@ -70,7 +75,7 @@ export SONATYPE_PASSWORD=your_sonatype_password
 VERSION=xx-version-to-release-xx
 
 # now from latest master, prepare the release. We are intentionally deferring pushing commits
-./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion=$VERSION -Darguments="-DskipTests -Dlicense.skip=true" release:prepare  -DpushChanges=false
+./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion=$VERSION -Darguments="-DskipTests" release:prepare -DpushChanges=false
 
 # once this works, deploy and synchronize to maven central
 git checkout $VERSION

--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.17.2</version>
+      <version>3.18.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -223,6 +223,13 @@
   <build>
     <pluginManagement>
       <plugins>
+        <!-- mvn de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -->
+        <plugin>
+          <groupId>de.qaware.maven</groupId>
+          <artifactId>go-offline-maven-plugin</artifactId>
+          <version>1.2.7</version>
+        </plugin>
+
         <!-- mvn -N io.takari:maven:wrapper generates the ./mvnw script -->
         <plugin>
           <groupId>io.takari</groupId>
@@ -479,7 +486,6 @@
           </plugin>
 
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>1.6</version>
             <executions>

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -141,6 +141,5 @@ elif is_travis_branch_master; then
 # If we are on a release tag, the following will update any version references and push a version tag for deployment.
 elif build_started_by_tag; then
   safe_checkout_master
-  # skip license on travis due to #1512
   ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion="$(release_version)" -Darguments="-DskipTests" release:prepare
 fi

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -118,9 +118,8 @@ fi
 if is_release_version; then
   true
 else
-  # verify runs both tests and integration tests (Docker tests included)
-  # -Dlicense.skip=true skips license on Travis due to #1512
-  ./mvnw verify -nsu -Dlicense.skip=true
+  # verify runs both tests and integration tests
+  ./mvnw verify -nsu
 fi
 
 # If we are on a pull request, our only job is to run tests, which happened above via ./mvnw install
@@ -132,7 +131,7 @@ if is_pull_request; then
 #    Sonatype and try again: https://oss.sonatype.org/#stagingRepositories
 elif is_travis_branch_master; then
   # -Prelease ensures the core jar ends up JRE 1.6 compatible
-  ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests -Dlicense.skip=true deploy
+  ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy
 
   if is_release_version; then
     # cleanup the release trigger, but don't fail if it was already there
@@ -143,5 +142,5 @@ elif is_travis_branch_master; then
 elif build_started_by_tag; then
   safe_checkout_master
   # skip license on travis due to #1512
-  ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion="$(release_version)" -Darguments="-DskipTests -Dlicense.skip=true" release:prepare
+  ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion="$(release_version)" -Darguments="-DskipTests" release:prepare
 fi


### PR DESCRIPTION
We've long since gotten to the bottom of this. Rather than always skipping the
license plugin in CI, causing a poor experience for people who have local builds
fail over it, this re-enables after underscoring the CI config needed to make it
work.

After this change, pull requests won't be green unless the headers are correct.