### PR TITLE
Switch from OSSRH to Sonatype Central Portal

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,9 +8,12 @@ name: deploy
 # See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
 on:
   push:
-    # Don't deploy tags as they conflict with [maven-release-plugin] prepare release MAJOR.MINOR.PATCH
-    tags: ''
-    branches: master
+    branches:
+      - master
+    # Don't deploy tags because the same commit for MAJOR.MINOR.PATCH is also
+    # on master: Redundant deployment of a release version will fail uploading.
+    tags-ignore:
+      - '*'
 
 jobs:
   deploy:
@@ -34,8 +37,8 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           # SONATYPE_USER=<sonatype account token>
           #   - deploys snapshots and releases to Sonatype
-          #   - needs access to io.zipkin via https://issues.sonatype.org/browse/OSSRH-16669
-          #   - generate via https://oss.sonatype.org/#profile;User%20Token
+          #   - needs access to io.zipkin namespace
+          #   - generate token at https://central.sonatype.com
           #   - referenced in .settings.xml
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           # SONATYPE_PASSWORD=<password to sonatype account token>

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,13 +6,18 @@ name: test
 on:
   # We run tests on non-tagged pushes to master that aren't a commit made by the release plugin
   push:
-    tags: ''
-    branches: master
-    paths-ignore: '**/*.md'
+    branches:
+      - master
+    tags-ignore:
+      - '*'
+    paths-ignore:
+      - '**/*.md'
   # We also run tests on pull requests targeted at the master branch.
   pull_request:
-    branches: master
-    paths-ignore: '**/*.md'
+    branches:
+      - master
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   test:

--- a/.settings.xml
+++ b/.settings.xml
@@ -15,7 +15,7 @@
       <passphrase>${env.GPG_PASSPHRASE}</passphrase>
     </server>
     <server>
-      <id>ossrh</id>
+      <id>central</id>
       <username>${env.SONATYPE_USER}</username>
       <password>${env.SONATYPE_PASSWORD}</password>
     </server>

--- a/README.md
+++ b/README.md
@@ -12,9 +12,8 @@ All artifacts publish to the group ID "io.zipkin.brave.karaf". We use a common
 release version for all components.
 
 ### Library Releases
-Snapshots are uploaded to [Sonatype](https://oss.sonatype.org/content/repositories/releases/io/zipkin/brave/karaf) which
-synchronizes with [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22io.zipkin.brave.karaf%22)
+Releases are at [Maven Central](https://central.sonatype.com/search?q=brave-karaf&namespace=io.zipkin.brave.karaf)
 
 ### Library Snapshots
-Snapshots are uploaded to [Sonatype](https://oss.sonatype.org/content/repositories/snapshots) after
+Snapshots are uploaded to [Sonatype](https://central.sonatype.com/repository/maven-snapshots/) after
 commits to master.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,7 +18,7 @@ This repo uses semantic versions. Please keep this in mind when choosing version
    which creates commits, `MAJOR.MINOR.PATCH` tag, and increments the version (maven-release-plugin).
 
    The `MAJOR.MINOR.PATCH` tag triggers [`build-bin/deploy`](build-bin/deploy), which does the following:
-   * Publishes jars to https://oss.sonatype.org/content/repositories/releases [`build-bin/maven/maven_deploy`](build-bin/maven/maven_deploy)
+   * Publishes jars to Sonatype [`build-bin/maven/maven_deploy`](build-bin/maven/maven_deploy)
       * Later, the same jars synchronize to Maven Central
 
    Notes:
@@ -31,7 +31,7 @@ look at the notes in [.github/workflows/deploy.yml] and check the [org secrets](
 
 ### Troubleshooting invalid credentials
 
-If you receive a '401 unauthorized' failure from OSSRH, it is likely
+If you receive a '401 unauthorized' failure from Sonatype, it is likely
 `SONATYPE_USER` or `SONATYPE_PASSWORD` entries are invalid, or possibly the
 user associated with them does not have rights to upload.
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,13 +22,9 @@
 
   <distributionManagement>
     <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <id>central</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
   </distributionManagement>
 
   <issueManagement>
@@ -78,7 +74,7 @@
     <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
-    <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
+    <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
   </properties>
 
   <name>Brave Karaf (Parent)</name>
@@ -243,9 +239,9 @@
         </plugin>
 
         <plugin>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>${nexus-staging-maven-plugin.version}</version>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>${central-publishing-maven-plugin.version}</version>
         </plugin>
 
         <plugin>
@@ -507,16 +503,13 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
             <extensions>true</extensions>
             <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <!-- Double the normal timeout even though we haven't had a problem in this project.
-                   The only outcome of timing out client side is trying again. -->
-              <stagingProgressTimeoutMinutes>10</stagingProgressTimeoutMinutes>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
             </configuration>
           </plugin>
 


### PR DESCRIPTION
Same as https://github.com/openzipkin/zipkin/pull/3817

OSSRH (oss.sonatype.org) was shut down June 30, 2025. This replaces nexus-staging-maven-plugin with central-publishing-maven-plugin and updates all references accordingly.

Manual steps already completed:
 * Generated token at https://central.sonatype.com account settings
 * Updated SONATYPE_USER/SONATYPE_PASSWORD at https://github.com/organizations/openzipkin/settings/secrets/actions
 * Enabled SNAPSHOTs at https://central.sonatype.com/publishing/namespaces (io.zipkin)