### PR TITLE
Add missing name to child modules for Sonatype Central Portal

### DIFF
--- a/features/pom.xml
+++ b/features/pom.xml
@@ -13,6 +13,7 @@
     <version>0.3.1-SNAPSHOT</version>
   </parent>
   <artifactId>brave-features</artifactId>
+  <name>Brave Karaf: Features</name>
   <packaging>pom</packaging>
 
   <properties>

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -13,6 +13,7 @@
     <version>0.3.1-SNAPSHOT</version>
   </parent>
   <artifactId>brave-itests</artifactId>
+  <name>Brave Karaf: Integration Tests</name>
 
   <properties>
     <pax-exam.version>4.13.5</pax-exam.version>


### PR DESCRIPTION
flattenMode=ossrh strips inherited names, so each child module needs an explicit name element.

Signed-off-by: Adrian Cole <adrian@tetrate.io>

